### PR TITLE
修复在linux 下破解器不能启动的报错

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using Avalonia;
+using Avalonia.Media;
 using Avalonia.ReactiveUI;
 
 namespace UniHacker
@@ -24,6 +25,10 @@ namespace UniHacker
             => AppBuilder.Configure<App>()
                 .UsePlatformDetect()
                 .LogToTrace()
+                .With(new FontManagerOptions
+                 {
+                    DefaultFamilyName = "avares://MyAssembly/MyAssets#MyCustomFont"
+                 })
                 .UseReactiveUI();
 
         static void Test()


### PR DESCRIPTION
修复BUG参考链接:
修复在linux 下破解器不能启动的报错
报错如下:
ubuntu@ubuntu-virtual-machine:~/下载/UniHacker-linux-x64$ chmod u+x UniHackerV4.5.AppImage  ubuntu@ubuntu-virtual-machine:~/下载/UniHacker-linux-x64$ ./UniHackerV4.5.AppImage  Unhandled exception. System.InvalidOperationException: Default font family name can't be null or empty.
   at Avalonia.Media.FontManager..ctor(IFontManagerImpl platformImpl) in /_/src/Avalonia.Visuals/Media/FontManager.cs:line 33
   at Avalonia.Media.FontManager.get_Current() in /_/src/Avalonia.Visuals/Media/FontManager.cs:line 53
   at Avalonia.Media.TextFormatting.TextCharacters.TryGetRunProperties(ReadOnlySlice`1 text, Typeface typeface, Typeface defaultTypeface, Int32& count) in /_/src/Avalonia.Visuals/Media/TextFormatting/TextCharacters.cs:line 129
   at Avalonia.Media.TextFormatting.TextCharacters.CreateShapeableRun(ReadOnlySlice`1 text, TextRunProperties defaultProperties) in /_/src/Avalonia.Visuals/Media/TextFormatting/TextCharacters.cs:line 62
   at Avalonia.Media.TextFormatting.TextCharacters.GetShapeableCharacters() in /_/src/Avalonia.Visuals/Media/TextFormatting/TextCharacters.cs:line 40
   at Avalonia.Media.TextFormatting.TextFormatterImpl.FetchTextRuns(ITextSource textSource, Int32 firstTextSourceIndex, TextLineBreak previousLineBreak, TextLineBreak& nextLineBreak) in /_/src/Avalonia.Visuals/Media/TextFormatting/TextFormatterImpl.cs:line 280
   at Avalonia.Media.TextFormatting.TextFormatterImpl.FormatLine(ITextSource textSource, Int32 firstTextSourceIndex, Double paragraphWidth, TextParagraphProperties paragraphProperties, TextLineBreak previousLineBreak) in /_/src/Avalonia.Visuals/Media/TextFormatting/TextFormatterImpl.cs:line 15
   at Avalonia.Media.TextFormatting.TextLayout.UpdateLayout() in /_/src/Avalonia.Visuals/Media/TextFormatting/TextLayout.cs:line 223
   at Avalonia.Media.TextFormatting.TextLayout..ctor(String text, Typeface typeface, Double fontSize, IBrush foreground, TextAlignment textAlignment, TextWrapping textWrapping, TextTrimming textTrimming, TextDecorationCollection textDecorations, Double maxWidth, Double maxHeight, Double lineHeight, Int32 maxLines, IReadOnlyList`1 textStyleOverrides) in /_/src/Avalonia.Visuals/Media/TextFormatting/TextLayout.cs:line 71
   at Avalonia.Controls.TextBlock.CreateTextLayout(Size constraint, String text) in /_/src/Avalonia.Controls/TextBlock.cs:line 475
   at Avalonia.Controls.TextBlock.get_TextLayout() in /_/src/Avalonia.Controls/TextBlock.cs:line 166
   at Avalonia.Controls.TextBlock.MeasureOverride(Size availableSize) in /_/src/Avalonia.Controls/TextBlock.cs:line 521
   at Avalonia.Layout.Layoutable.MeasureCore(Size availableSize) in /_/src/Avalonia.Layout/Layoutable.cs:line 559
   at Avalonia.Layout.Layoutable.Measure(Size availableSize) in /_/src/Avalonia.Layout/Layoutable.cs:line 364
   at Avalonia.Layout.Layoutable.MeasureOverride(Size availableSize) in /_/src/Avalonia.Layout/Layoutable.cs:line 625
   at Avalonia.Layout.Layoutable.MeasureCore(Size availableSize) in /_/src/Avalonia.Layout/Layoutable.cs:line 559
   at Avalonia.Layout.Layoutable.Measure(Size availableSize) in /_/src/Avalonia.Layout/Layoutable.cs:line 364
   at Avalonia.Layout.LayoutHelper.MeasureChild(ILayoutable control, Size availableSize, Thickness padding) in /_/src/Avalonia.Layout/LayoutHelper.cs:line 46
   at Avalonia.Layout.LayoutHelper.MeasureChild(ILayoutable control, Size availableSize, Thickness padding, Thickness borderThickness) in /_/src/Avalonia.Layout/LayoutHelper.cs:line 39
   at Avalonia.Controls.Border.MeasureOverride(Size availableSize) in /_/src/Avalonia.Controls/Border.cs:line 187
   at Avalonia.Layout.Layoutable.MeasureCore(Size availableSize) in /_/src/Avalonia.Layout/Layoutable.cs:line 559
   at Avalonia.Layout.Layoutable.Measure(Size availableSize) in /_/src/Avalonia.Layout/Layoutable.cs:line 364
   at Avalonia.Layout.LayoutHelper.MeasureChild(ILayoutable control, Size availableSize, Thickness padding) in /_/src/Avalonia.Layout/LayoutHelper.cs:line 46
   at Avalonia.Layout.LayoutHelper.MeasureChild(ILayoutable control, Size availableSize, Thickness padding, Thickness borderThickness) in /_/src/Avalonia.Layout/LayoutHelper.cs:line 39
   at Avalonia.Controls.Presenters.ContentPresenter.MeasureOverride(Size availableSize) in /_/src/Avalonia.Controls/Presenters/ContentPresenter.cs:line 366
   at Avalonia.Layout.Layoutable.MeasureCore(Size availableSize) in /_/src/Avalonia.Layout/Layoutable.cs:line 559
   at Avalonia.Layout.Layoutable.Measure(Size availableSize) in /_/src/Avalonia.Layout/Layoutable.cs:line 364
   at Avalonia.Layout.LayoutHelper.MeasureChild(ILayoutable control, Size availableSize, Thickness padding) in /_/src/Avalonia.Layout/LayoutHelper.cs:line 46
   at Avalonia.Controls.Primitives.VisualLayerManager.MeasureOverride(Size availableSize) in /_/src/Avalonia.Controls/Primitives/VisualLayerManager.cs:line 133
   at Avalonia.Layout.Layoutable.MeasureCore(Size availableSize) in /_/src/Avalonia.Layout/Layoutable.cs:line 559
   at Avalonia.Layout.Layoutable.Measure(Size availableSize) in /_/src/Avalonia.Layout/Layoutable.cs:line 364
   at Avalonia.Layout.Layoutable.MeasureOverride(Size availableSize) in /_/src/Avalonia.Layout/Layoutable.cs:line 625
   at Avalonia.Layout.Layoutable.MeasureCore(Size availableSize) in /_/src/Avalonia.Layout/Layoutable.cs:line 559
   at Avalonia.Layout.Layoutable.Measure(Size availableSize) in /_/src/Avalonia.Layout/Layoutable.cs:line 364
   at Avalonia.Layout.Layoutable.MeasureOverride(Size availableSize) in /_/src/Avalonia.Layout/Layoutable.cs:line 625
   at Avalonia.Controls.Window.MeasureOverride(Size availableSize) in /_/src/Avalonia.Controls/Window.cs:line 916
   at Avalonia.Controls.WindowBase.MeasureCore(Size availableSize) in /_/src/Avalonia.Controls/WindowBase.cs:line 243
   at Avalonia.Layout.Layoutable.Measure(Size availableSize) in /_/src/Avalonia.Layout/Layoutable.cs:line 364
   at Avalonia.Layout.LayoutManager.Measure(ILayoutable control) in /_/src/Avalonia.Layout/LayoutManager.cs:line 287
   at Avalonia.Layout.LayoutManager.ExecuteInitialLayoutPass() in /_/src/Avalonia.Layout/LayoutManager.cs:line 174
   at Avalonia.Controls.Window.ShowCore(Window parent) in /_/src/Avalonia.Controls/Window.cs:line 693
   at Avalonia.Controls.Window.Show() in /_/src/Avalonia.Controls/Window.cs:line 631
   at Avalonia.Controls.ApplicationLifetimes.ClassicDesktopStyleApplicationLifetime.ShowMainWindow() in /_/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs:line 129
   at Avalonia.Controls.ApplicationLifetimes.ClassicDesktopStyleApplicationLifetime.Start(String[] args) in /_/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs:line 118
   at Avalonia.ClassicDesktopStyleApplicationLifetimeExtensions.StartWithClassicDesktopLifetime[T](T builder, String[] args, ShutdownMode shutdownMode) in /_/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs:line 209
   at UniHacker.Program.Main(String[] args)
已放弃 (核心已转储)
ubuntu@ubuntu-virtual-machine:~/下载/UniHacker-linux-x64$